### PR TITLE
Add patches for aarch64

### DIFF
--- a/__uk_init_tls.c
+++ b/__uk_init_tls.c
@@ -94,7 +94,7 @@ void *__uk_copy_tls(unsigned char *mem)
 	tls_area = mem;
 	ukarch_tls_area_init(tls_area);
 
-	td = (pthread_t) ukarch_tls_tlsp(tls_area);
+	td = (pthread_t) ukarch_tls_tcb_get(ukarch_tls_tlsp(tls_area));
 	td->dtv = td->dtv_copy = tls_area;
 
 	return td;

--- a/patches/0018-Field-name-__unused-conflicts-with-Unikraft-__unused.patch
+++ b/patches/0018-Field-name-__unused-conflicts-with-Unikraft-__unused.patch
@@ -1,0 +1,25 @@
+From 814aa07bf4b566f51f7f81bb0a18f4689188f83e Mon Sep 17 00:00:00 2001
+From: Robert Kuban <robert.kuban@opensynergy.com>
+Date: Mon, 18 Jul 2022 13:19:41 +0200
+Subject: [PATCH 1/3] Field name `__unused` conflicts with Unikraft `__unused`
+ macro.
+
+Signed-off-by: Robert Kuban <robert.kuban@opensynergy.com>
+---
+ arch/aarch64/bits/stat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/aarch64/bits/stat.h b/arch/aarch64/bits/stat.h
+index b7f4221b..d1778f74 100644
+--- a/arch/aarch64/bits/stat.h
++++ b/arch/aarch64/bits/stat.h
+@@ -14,5 +14,5 @@ struct stat {
+ 	struct timespec st_atim;
+ 	struct timespec st_mtim;
+ 	struct timespec st_ctim;
+-	unsigned __unused[2];
++	unsigned _pad[2];
+ };
+-- 
+2.25.1
+

--- a/patches/0019-Modify-clone-wrapper.patch
+++ b/patches/0019-Modify-clone-wrapper.patch
@@ -1,0 +1,61 @@
+From 2ad50560ffad11f6bc1c7788ae733760f6d85f7f Mon Sep 17 00:00:00 2001
+From: Robert Kuban <robert.kuban@opensynergy.com>
+Date: Thu, 11 Aug 2022 18:03:23 +0200
+Subject: [PATCH] Modify clone wrapper
+
+Signed-off-by: Robert Kuban <robert.kuban@opensynergy.com>
+---
+ src/thread/aarch64/clone.s | 24 ++++++++++++++++--------
+ 1 file changed, 16 insertions(+), 8 deletions(-)
+
+diff --git a/src/thread/aarch64/clone.s b/src/thread/aarch64/clone.s
+index 50af913c..cd1f956b 100644
+--- a/src/thread/aarch64/clone.s
++++ b/src/thread/aarch64/clone.s
+@@ -1,12 +1,19 @@
+ // __clone(func, stack, flags, arg, ptid, tls, ctid)
+ //         x0,   x1,    w2,    x3,  x4,   x5,  x6
+ 
+-// syscall(SYS_clone, flags, stack, ptid, tls, ctid)
+-//         x8,        x0,    x1,    x2,   x3,  x4
++// see: lib/posix-process/clone.c
++// uk_syscall_r_clone(flags, stack, ptid, tlsp, ctid)
++//                    x0,    x1,    x2,   x3,   x4
++
++// see: lib/posix-process/process.c
++// uk_syscall_r_exit(status)
++//                   x0
+ 
+ .global __clone
+ .type   __clone,%function
+ __clone:
++	stp x29, x30, [sp, #-16]!
++
+ 	// align stack and save func,arg
+ 	and x1,x1,#-16
+ 	stp x0,x3,[x1,#-16]!
+@@ -16,14 +23,15 @@ __clone:
+ 	mov x2,x4
+ 	mov x3,x5
+ 	mov x4,x6
+-	mov x8,#220 // SYS_clone
+-	svc #0
++	bl uk_syscall_r_clone
+ 
+ 	cbz x0,1f
+ 	// parent
++	ldp x29, x30, [sp], #16
+ 	ret
+-	// child
++	// child (SP is X1 from syscall now)
+ 1:	ldp x1,x0,[sp],#16
+-	blr x1
+-	mov x8,#93 // SYS_exit
+-	svc #0
++	blr x1 // call func(arg)
++	mov x0, xzr
++	bl uk_syscall_r_exit
++	wfi
+-- 
+2.25.1
+

--- a/patches/0020-use_openat_ifndef_SYS_open.patch
+++ b/patches/0020-use_openat_ifndef_SYS_open.patch
@@ -1,0 +1,28 @@
+diff --git a/src/internal/syscall.h b/src/internal/syscall.h
+index 5bdb9ea9..c27e4915 100644
+--- a/src/internal/syscall.h
++++ b/src/internal/syscall.h
+@@ -201,7 +201,11 @@ long __syscall_ret(unsigned long), __syscall(uk_syscall_arg_t, ...),
+ #define __SC_recvmmsg    19
+ #define __SC_sendmmsg    20
+ 
++#ifdef SYS_open
+ #define __sys_open(...) uk_syscall_r_static(SYS_open, __VA_ARGS__)
++#else
++#define __sys_open(...) uk_syscall_r_static(SYS_openat, AT_FDCWD,__VA_ARGS__)
++#endif
+ #define sys_open(...) __syscall_ret(__sys_open(__VA_ARGS__))
+ 
+ /**
+@@ -209,7 +213,11 @@ long __syscall_ret(unsigned long), __syscall(uk_syscall_arg_t, ...),
+  * However, we currently don't support this operation.
+  * Hence, we stick to the basic uk_syscall
+  */
++#ifdef SYS_open
+ #define __sys_open_cp(...) uk_syscall_r_static(SYS_open, __VA_ARGS__)
++#else
++#define __sys_open_cp(...) uk_syscall_r_static(SYS_openat, AT_FDCWD, __VA_ARGS__)
++#endif
+ #define sys_open_cp(...) __syscall_ret(__sys_open_cp(__VA_ARGS__))
+ 
+ #endif


### PR DESCRIPTION
This pull request adds 3 patches, which:
- solve the naming conflict with `__unused` similar to patch 003, but for aarch64
- add the missing syscall macros for `CONFIG_ARCH_ARM_64`
- change the `__clone` wrapper to use a function call instead of a system call (similar to the patch by @dragosargint for x64_64

It also fixes an problem in `uk_init_tls` on aarch64 by returning tcb pointer in `__uk_copy_tls` instead of the tlsp.

This PR applies on top of PR #9 and should be used together with #7.