### PR TITLE
Comment macros to stop using VDSO

### DIFF
--- a/patches/0015-Comment-macros-to-stop-using-VDSO.patch
+++ b/patches/0015-Comment-macros-to-stop-using-VDSO.patch
@@ -1,0 +1,74 @@
+From 52d58e37701b1433b45721107fa4c143a35ce7d0 Mon Sep 17 00:00:00 2001
+From: Florin Postolache <florin.postolache80@gmail.com>
+Date: Mon, 18 Jul 2022 20:39:32 +0300
+Subject: [PATCH] Comment macros to stop using VDSO
+
+The VDSO is responsible for the virtual system calls in a basic
+linux application and makes so that some system calls will be faster
+because the transition between kernel mode and user mode is eliminated.
+Therefore, it shouldn't be used in Unikraft. At the moment, in musl
+this feature is enabled and functions like __clock_gettime will generate
+a segfault.
+
+Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>
+---
+ arch/aarch64/syscall_arch.h | 2 +-
+ arch/arm/syscall_arch.h     | 2 +-
+ arch/i386/syscall_arch.h    | 2 +-
+ arch/x86_64/syscall_arch.h  | 4 ++--
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/arch/aarch64/syscall_arch.h b/arch/aarch64/syscall_arch.h
+index 25f5ce6..1b7a22f 100644
+--- a/arch/aarch64/syscall_arch.h
++++ b/arch/aarch64/syscall_arch.h
+@@ -72,5 +72,5 @@ static inline long __syscall6(long n, long a, long b, long c, long d, long e, lo
+ }
+ 
+ #define VDSO_USEFUL
+-#define VDSO_CGT_SYM "__kernel_clock_gettime"
++//#define VDSO_CGT_SYM "__kernel_clock_gettime"
+ #define VDSO_CGT_VER "LINUX_2.6.39"
+diff --git a/arch/arm/syscall_arch.h b/arch/arm/syscall_arch.h
+index 6023303..bb949c3 100644
+--- a/arch/arm/syscall_arch.h
++++ b/arch/arm/syscall_arch.h
+@@ -74,7 +74,7 @@ static inline long __syscall6(long n, long a, long b, long c, long d, long e, lo
+ }
+ 
+ #define VDSO_USEFUL
+-#define VDSO_CGT_SYM "__vdso_clock_gettime"
++//#define VDSO_CGT_SYM "__vdso_clock_gettime"
+ #define VDSO_CGT_VER "LINUX_2.6"
+ 
+ #define SYSCALL_FADVISE_6_ARG
+diff --git a/arch/i386/syscall_arch.h b/arch/i386/syscall_arch.h
+index 4c9d874..06f1d35 100644
+--- a/arch/i386/syscall_arch.h
++++ b/arch/i386/syscall_arch.h
+@@ -53,7 +53,7 @@ static inline long __syscall6(long n, long a1, long a2, long a3, long a4, long a
+ }
+ 
+ #define VDSO_USEFUL
+-#define VDSO_CGT_SYM "__vdso_clock_gettime"
++//#define VDSO_CGT_SYM "__vdso_clock_gettime"
+ #define VDSO_CGT_VER "LINUX_2.6"
+ 
+ #define SYSCALL_USE_SOCKETCALL
+diff --git a/arch/x86_64/syscall_arch.h b/arch/x86_64/syscall_arch.h
+index 54e05ff..847cf2c 100644
+--- a/arch/x86_64/syscall_arch.h
++++ b/arch/x86_64/syscall_arch.h
+@@ -62,7 +62,7 @@ static __inline long __syscall6(long n, long a1, long a2, long a3, long a4, long
+ }
+ 
+ #define VDSO_USEFUL
+-#define VDSO_CGT_SYM "__vdso_clock_gettime"
++//#define VDSO_CGT_SYM "__vdso_clock_gettime"
+ #define VDSO_CGT_VER "LINUX_2.6"
+-#define VDSO_GETCPU_SYM "__vdso_getcpu"
++//#define VDSO_GETCPU_SYM "__vdso_getcpu"
+ #define VDSO_GETCPU_VER "LINUX_2.6"
+-- 
+2.25.1
+


### PR DESCRIPTION
The VDSO is responsible for the virtual system calls in a basic
linux application and makes so that some system calls will be faster
because the transition between kernel mode and user mode is eliminated.
Therefore, it shouldn't be used in Unikraft. At the moment, in musl
this feature is enabled and functions like `__clock_gettime` will generate
a segfault. This PR contains changes that disable the use of vdso for the 
current used architectures and use the system calls directly.
