### PR TITLE
Hide internal headers

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -18,13 +18,16 @@ $(LIBMUSL_BUILD)/include/$(1)/%.h:
 	$(call verbose_cmd,HOSTLN,libmusl: $(1): $$(subst $(LIBMUSL_BUILD)/include/$(1)/,,$$@), \
 		ln -sf $$(subst $(LIBMUSL_BUILD)/include/$(1)/,$(LIBMUSL),$$@) $$@)
 
-LIBMUSL_$(call uc,$(1))_INCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/include
+# includes for building libmusl
 LIBMUSL_$(call uc,$(1))_INCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/src/internal
 LIBMUSL_$(call uc,$(1))_INCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/src/$(1)
 LIBMUSL_SRCS-y += $(3)
+LIBMUSL_CINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)
+LIBMUSL_CXXINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)
 
-CINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)
-CXXINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)
+# includes for using libmusl
+CINCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/include
+CXXINCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/include
 
 # Append the sub library directory to the include path
 $(LIBMUSL_BUILD)/.prepared: $(subst $(LIBMUSL),$(LIBMUSL_BUILD)/include/$(1),$(2))

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -92,7 +92,7 @@ $(LIBMUSL)/arch/$(ARCH)/bits/alltypes.h: $(LIBMUSL_BUILD)/.patched
 # generate version.h
 $(LIBMUSL)/src/internal/version.h:
 	$(call verbose_cmd,CONFIGURE,libmusl: $(notdir $@),\
-		printf '#define VERSION "%s"\n' "$$(cd $(LIBMUSL); sh tools/version.sh)" > $@ \
+		printf '#define VERSION "%s"\n' "$$(cd $(LIBMUSL); sh tools/version.sh)" > $@ && \
 		$(TOUCH) $@)
 
 UK_PREPARE += $(LIBMUSL)/arch/$(ARCH)/bits/alltypes.h
@@ -137,6 +137,7 @@ LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/mem.c
 LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/__uk_init_tls.c
 LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/__uk_unmapself.c
 LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/__set_thread_area.c
+LIBMUSLGLUE_CINCLUDES += -I$(LIBMUSL)/src/internal
 
 ################################################################################
 # Core Standard Library


### PR DESCRIPTION
This patch applies on top of #9, and includes two changes:

* Before, musl has exposed internal headers to other code, now the include paths are added to the appropriate variable.
* The rule to generate `src/internal/version.h` previously had a typo, leading to multiple definitions of VERSION.