### PR TITLE
Enable FPSIMD support on ARM64

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -26,6 +26,7 @@ menuconfig LIBMUSL
   select LIBMUSL_ENV
 
   select LIBSYSCALL_SHIM_NOWRAPPER
+  select FPSIMD if ARCH_ARM_64
 
 if LIBMUSL
 


### PR DESCRIPTION
Some of the functions implemented in musl can't work without the ARM64 FPSIMD registers. This will fail unikraft build with musl
when FPSIMD is not enabled. This PR enables FPSIMD by default when lib-musl is selected in menuconfig.

Signed-off-by: Razvan Virtan <virtanrazvan@gmail.com>