### PR TITLE
Introduce depedency to enable parallel build

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -90,7 +90,7 @@ $(LIBMUSL)/arch/$(ARCH)/bits/alltypes.h: $(LIBMUSL_BUILD)/.patched
 		$(TOUCH) $@)
 
 # generate version.h
-$(LIBMUSL)/src/internal/version.h:
+$(LIBMUSL)/src/internal/version.h: fetch
 	$(call verbose_cmd,CONFIGURE,libmusl: $(notdir $@),\
 		printf '#define VERSION "%s"\n' "$$(cd $(LIBMUSL); sh tools/version.sh)" > $@ \
 		$(TOUCH) $@)


### PR DESCRIPTION
This patch applies on top of https://github.com/unikraft/lib-musl/pull/9

Parallel build with `make -jN` breaks as generating `version.h` is not depended on the fetch step:
```
$ make -j5
make[1]: Entering directory '/home/.../unikraft'
  LN      Makefile
  MKDIR   lxdialog
  CP      config
  WGET    libmusl: https://www.musl-libc.org/releases/musl-1.1.19.tar.gz
  CONFIGURE libmusl: version.h
/bin/bash: line 0: cd: /home/.../app-helloworld/build/libmusl/origin/musl-1.1.19/: No such file or directory
sh: 0: Can't open tools/version.sh
/bin/bash: /home/.../app-helloworld/build/libmusl/origin/musl-1.1.19//src/internal/version.h: No such file or directory
...
```

This commit introduces that dependency.