### PR TITLE
Remove include directory from clean list

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -93,7 +93,6 @@ UK_PREPARE += $(LIBMUSL_BUILD)/.prepared
 
 LIBMUSL_CLEAN += $(LIBMUSL)/arch/$(ARCH)/bits/alltypes.h
 LIBMUSL_CLEAN += $(LIBMUSL)/src/internal/version.h
-LIBMUSL_CLEAN += $(LIBMUSL_BUILD)/include
 
 ################################################################################
 # Global flags


### PR DESCRIPTION
The current clean rule in the Unikraft build system can not remove directories and terminated with an error if there is a directory in the list of files to clean.

This commit removes the include directory inside the lib-musl build directory from the clean list.

Since each sublibraries has a separate subdirectories in the include directory, this change will not make headers accessible which would have been deleted by the clean rule.

Alternatives considered:

1. Enable the build build rule to remove directories.
This would lead to the uk_clean_list not containing a complete lists of files to remove anymore and makes the potencial damage of errors in the clean list much higher.

2. Add every header file into the `LIBMUSL_CLEAN` variable.
This could be done in `_libmusl_import_lib` and would remove the linked headers, but would still leave the directory tree.

3. Do not create the links, but include from the origin directory.
This would remove the ability to filter header files in the sublibrary makefile.