### PR TITLE
Makefile.uk/misc: Always include the uname sources 

### DIFF
--- a/Makefile.uk.musl.misc
+++ b/Makefile.uk.musl.misc
@@ -76,9 +76,7 @@ LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/setpriority.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/setrlimit.c
 #LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/syscall.c|misc
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/syslog.c
-ifneq ($(CONFIG_LIBPOSIX_SYSINFO),y)
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/uname.c
-endif
 #LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/wordexp.c
 
 $(eval $(call _libmusl_import_lib,misc,$(LIBMUSL_MISC_HDRS-y),$(LIBMUSL_MISC_SRCS-y)))


### PR DESCRIPTION
When `LIB_POSIX_SYSINFO` is selected, the build fails when using musl with an undefined reference to `uname`.
This commit removes the `uname` sources dependency of the selection of `LIB_POSIX_SYSINFO`.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>