### PR TITLE
Update Makefile for LWIP integration

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -102,7 +102,7 @@ LIBMUSL_HDRS_FLAGS-y += -Wno-unused-value
 LIBMUSL_HDRS_FLAGS-y += -Wno-parentheses
 LIBMUSL_HDRS_FLAGS-y += -Wno-error=sign-compare
 LIBMUSL_HDRS_FLAGS-y += -Wno-builtin-macro-redefined
-LIBMUSL_HDRS_FLAGS-y += -D_POSIX_SOURCE -D_BSD_SOURCE
+LIBMUSL_HDRS_FLAGS-y += -D_XOPEN_SOURCE=700
 
 LIBMUSL_CFLAGS-y += -Wno-implicit-fallthrough
 LIBMUSL_CFLAGS-y += -Wno-restrict

--- a/Makefile.uk.musl.network
+++ b/Makefile.uk.musl.network
@@ -34,7 +34,6 @@ LIBMUSL_NETWORK_HDRS-y += $(LIBMUSL)/include/sys/un.h
 LIBMUSL_NETWORK_HDRS-y += $(LIBMUSL)/include/time.h
 LIBMUSL_NETWORK_HDRS-y += $(LIBMUSL)/include/unistd.h
 
-ifneq ($(CONFIG_LIBPOSIX_SOCKET),y)
 LIBMUSL_NETWORK_HDRS-y += $(LIBMUSL)/include/sys/socket.h
 
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/socket.c
@@ -57,7 +56,6 @@ LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/sendmsg.c
 # LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/sendmmsg.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/sendto.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/socketpair.c
-endif
 
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/dn_comp.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/dn_expand.c


### PR DESCRIPTION
This PR makes Musl compatible with LWIP and remove some build warnings.