### PR TITLE
Makefile.uk: Add sources for POSIX_USER functions 

### DIFF
--- a/Makefile.uk.musl.linux
+++ b/Makefile.uk.musl.linux
@@ -74,9 +74,7 @@ LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/sendfile.c
 endif
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/setfsgid.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/setfsuid.c
-ifneq ($(CONFIG_LIBPOSIX_USER),y)
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/setgroups.c
-endif
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/sethostname.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/setns.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/settimeofday.c

--- a/Makefile.uk.musl.misc
+++ b/Makefile.uk.musl.misc
@@ -55,11 +55,12 @@ LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/getpriority.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/getrlimit.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/getrusage.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/getsubopt.c
-ifneq ($(CONFIG_LIBPOSIX_USER),y)
+
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/getresgid.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/getresuid.c
-LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/initgroups.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/ioctl.c
+ifneq ($(CONFIG_LIBPOSIX_USER),y)
+LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/initgroups.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/issetugid.c
 endif
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/lockf.c

--- a/Makefile.uk.musl.unistd
+++ b/Makefile.uk.musl.unistd
@@ -38,14 +38,15 @@ LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/fdatasync.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/fsync.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/ftruncate.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getcwd.c
-ifneq ($(CONFIG_LIBPOSIX_USER),y)
+
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getegid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/geteuid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getgid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getgroups.c
+LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getuid.c
+ifneq ($(CONFIG_LIBPOSIX_USER),y)
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getlogin.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getlogin_r.c
-LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/getuid.c
 endif
 
 ifneq ($(CONFIG_LIBPOSIX_SYSINFO),y)
@@ -77,20 +78,22 @@ LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/readlinkat.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/readv.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/renameat.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/rmdir.c
-ifneq ($(CONFIG_LIBPOSIX_USER),y)
-LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setegid.c
-LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/seteuid.c
+
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setgid.c
-LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setpgid.c
-LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setpgrp.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setregid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setresgid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setresuid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setreuid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setuid.c
+ifneq ($(CONFIG_LIBPOSIX_USER),y)
+LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setegid.c
+LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/seteuid.c
+endif
+LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setpgid.c
+LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setpgrp.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setsid.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/setxid.c
-endif
+
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/sleep.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/symlink.c
 LIBMUSL_UNISTD_SRCS-y += $(LIBMUSL)/src/unistd/symlinkat.c


### PR DESCRIPTION
Since libc style syscall stubs are disabled when
using musl, many of the sources should be always
included to avoid `undefined refrence` errors.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>