### PR TITLE
Config.uk: Add posix socket dependecy for `libmq`

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -107,6 +107,7 @@ config LIBMUSL_MMAN
   default y
 
 config LIBMUSL_MQ
+  select LIBPOSIX_SOCKET
   bool "libmq"
   default y
 


### PR DESCRIPTION
`libmq` is dependent on having `posix-socket` as an internal library selected, therefore, this PR automatically enables it in `Config.uk`.

Before, building simple apps, such as `helloworld` failed on both `x86` and `AArch64` due to undefined references:

```bash
/home/maria/test-musl/scripts/musl/workdir/apps/app-helloworld/build/libmusl/origin/musl-1.1.19//src/mq/mq_notify.c:25: undefined reference to `recv'
/home/maria/test-musl/scripts/musl/workdir/apps/app-helloworld/build/libmusl/origin/musl-1.1.19//src/mq/mq_notify.c:25:(.text+0x2af94): relocation truncated to fit: R_AARCH64_CALL26 against undefined symbol `recv'
```

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>