### PR TITLE
Makefile.uk.musl.complex: Include tgmath.h header

### DIFF
--- a/Makefile.uk.musl.complex
+++ b/Makefile.uk.musl.complex
@@ -1,6 +1,9 @@
 LIBMUSL_COMPLEX_HDRS-y += $(LIBMUSL)/include/complex.h
 LIBMUSL_COMPLEX_HDRS-y += $(LIBMUSL)/include/float.h
 LIBMUSL_COMPLEX_HDRS-y += $(LIBMUSL)/src/intenal/libm.h
+ifeq ($(CONFIG_LIBMUSL_MATH),y)
+    LIBMUSL_COMPLEX_HDRS-y += $(LIBMUSL)/include/tgmath.h
+endif
 
 LIBMUSL_COMPLEX_SRCS-y += $(LIBMUSL)/src/complex/casinh.c
 LIBMUSL_COMPLEX_SRCS-y += $(LIBMUSL)/src/complex/csinhl.c


### PR DESCRIPTION
Add tgmath.h header when both complex and math sublibs are enabled.

Signed-off-by: Florin Postolache <florin.postolache80@gmail.com>