### PR TITLE
uk_init_tls: Change `uk_thread_tcb_fini` to `uk_thread_uktcb_fini`

### DIFF
--- a/__uk_init_tls.c
+++ b/__uk_init_tls.c
@@ -182,7 +182,7 @@ int uk_thread_uktcb_init(struct uk_thread *thread, void *tcb)
 /* This callback will only be called for threads that are NOT
  * created with the pthread API
  */
-void uk_thread_tcb_fini(struct uk_thread *thread, void *tcb)
+void uk_thread_uktcb_fini(struct uk_thread *thread, void *tcb)
 {
 	struct pthread *td = (struct pthread *) tcb;
 


### PR DESCRIPTION
This PR fixes a typo in which the function`uk_thread_uktcb_fini()`, as declared in uksched's `tcb_impl.h`, was incorrectly referred to as `uk_thread_tcb_fini()`.

A similar typo was found in Unikraft core, which means this PR must be merged together with https://github.com/unikraft/unikraft/pull/660.

Signed-off-by: Eduard Vintilă <eduard.vintila47@gmail.com>