### PR TITLE
`Makefile.uk`: Use `-Wno-cast-function-type` for GCC >= 8

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -122,7 +122,7 @@ LIBMUSL_CFLAGS-y += -Wno-empty-body
 LIBMUSL_CFLAGS-y += -Wno-maybe-uninitialized
 LIBMUSL_CFLAGS-y += -Wno-unknown-pragmas
 LIBMUSL_CFLAGS-y += -Wno-missing-braces
-LIBMUSL_CFLAGS-y += -Wno-cast-function-type
+LIBMUSL_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
 LIBMUSL_CFLAGS-y += -Wno-format-contains-nul
 LIBMUSL_CFLAGS-y += -Wno-type-limits
 LIBMUSL_CFLAGS-y += -DUK_LIBC_SYSCALL=0


### PR DESCRIPTION
The build option `-Wno-cast-function-type`, used in `Makefile.uk` is available from GCC >= 8. When used in GCC <= 7, it issues a warning.

This commit updates the build flags to enable `-Wno-cast-function-type` only when using GCC >= 8.

Fixes #27