### PR TITLE
Use function declaration for getdents64

### DIFF
--- a/patches/0022-include-Use-function-declaration-for-getdents64.patch
+++ b/patches/0022-include-Use-function-declaration-for-getdents64.patch
@@ -1,0 +1,33 @@
+From 40feadbd7fb360033089787a60b7d58deaae4892 Mon Sep 17 00:00:00 2001
+Message-Id: <40feadbd7fb360033089787a60b7d58deaae4892.1669764551.git.razvand@unikraft.io>
+From: Razvan Deaconescu <razvand@unikraft.io>
+Date: Wed, 30 Nov 2022 01:27:36 +0200
+Subject: [PATCH] include: Use function declaration for getdents64()
+
+When defining `getdents64` as a macro aliasing `getdents`, the syscall
+shim layer complains.
+
+The declaration of `getdents64()`, combined with the `LFS64(getdents)`
+aliasing used in `src/dirent/__getdents.c` solves this.
+
+Signed-off-by: Razvan Deaconescu <razvand@unikraft.io>
+---
+ include/dirent.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/dirent.h b/include/dirent.h
+index e0a8fe6..12bb28c 100644
+--- a/include/dirent.h
++++ b/include/dirent.h
+@@ -75,7 +75,7 @@ int versionsort(const struct dirent **, const struct dirent **);
+ #define versionsort64 versionsort
+ #define off64_t off_t
+ #define ino64_t ino_t
+-#define getdents64 getdents
++int getdents64(int, struct dirent64 *, size_t);
+ #endif
+ 
+ #ifdef __cplusplus
+-- 
+2.17.1
+


### PR DESCRIPTION
When defining `getdents64` as a macro aliasing `getdents`, the syscall shim layer complains.
    
This patch uses a typical C-style declaration of `getdents64()`. This, combined with the `LFS64(getdents)`, aliasing used in `src/dirent/__getdents.c` solves the issue with the syscall shim layer.

The `getdents64` symbol is then provided to applications as an alias to `getdents`, while the `uk_syscall_getdents64` syscall is provided by Unikraft:

```
razvan@yggdrasil:~/.../workdir/apps/app-nginx$ nm build/libmusl.o | grep getdents
00000000000002e0 W getdents
00000000000002e0 T __getdents
00000000000002e0 W getdents64
                 U uk_syscall_r_getdents64
razvan@yggdrasil:~/.../workdir/apps/app-nginx$ nm build/nginx_kvm-x86_64.dbg | grep getdents
000000000014d9a0 t getdents
000000000014d9a0 t __getdents
000000000014d9a0 t getdents64
0000000000144420 t uk_syscall_e_getdents
0000000000144600 t uk_syscall_e_getdents64
00000000001442b0 t __uk_syscall_r_getdents
00000000001443e0 t uk_syscall_r_getdents
0000000000144490 t __uk_syscall_r_getdents64
00000000001445c0 t uk_syscall_r_getdents64
```