### PR TITLE
Apply -ffreestanding for the musl source code

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -145,6 +145,10 @@ LIBMUSL_CFLAGS-y += -DUK_LIBC_SYSCALL=0
 LIBMUSL_CFLAGS-y += -D_XOPEN_SOURCE=700
 LIBMUSL_CFLAGS-y += $(LIBMUSL_HDRS_FLAGS-y)
 
+# musl cannot rely on a libc library. Therefore, compile it as freestanding
+# code.
+LIBMUSL_CFLAGS-y += -ffreestanding
+
 # We globally switch off warnings that are caused by musl's public headers
 CFLAGS += $(LIBMUSL_HDRS_FLAGS-y)
 CXXFLAGS += $(LIBMUSL_HDRS_FLAGS-y)


### PR DESCRIPTION
This is the corresponding commit for unikraft/unikraft#740. This prevents a self dependency caused by compiler optimizations, because the libc implementation cannot rely on underlying presence of a libc.

Signed-off-by: Marco Schlumpp <marco@unikraft.io>