### PR TITLE
Makefile.uk: Add flag to avoid gcc specifc symbol

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -141,6 +141,9 @@ LIBMUSL_CFLAGS-y += -Wno-missing-braces
 LIBMUSL_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
 LIBMUSL_CFLAGS-y += -Wno-format-contains-nul
 LIBMUSL_CFLAGS-y += -Wno-type-limits
+ifeq ($(CONFIG_LIBMUSL_COMPLEX),y)
+LIBMUSL_CFLAGS-$(call have_clang) += -ffast-math
+endif
 LIBMUSL_CFLAGS-y += -DUK_LIBC_SYSCALL=0
 LIBMUSL_CFLAGS-y += -D_XOPEN_SOURCE=700
 LIBMUSL_CFLAGS-y += $(LIBMUSL_HDRS_FLAGS-y)


### PR DESCRIPTION
When building apps with `clang` for `x86`, an asm specific symbol, `__muldc3`, which results in a undefined reference error, at link time.

This PR adds the `-ffast-math` flag, when `clang` is used in order to fix this issue.