### PR TITLE
Fix ioctl signature

### DIFF
--- a/patches/0020-Use-ulong-in-ioctl.patch
+++ b/patches/0020-Use-ulong-in-ioctl.patch
@@ -1,0 +1,13 @@
+diff --git a/include/sys/ioctl.h b/include/sys/ioctl.h
+index a9a2346..fed6b30 100644
+--- a/include/sys/ioctl.h
++++ b/include/sys/ioctl.h
+@@ -112,7 +112,7 @@ extern "C" {
+ #define SIOCDEVPRIVATE     0x89F0
+ #define SIOCPROTOPRIVATE   0x89E0
+ 
+-int ioctl (int, int, ...);
++int ioctl (int, unsigned long, ...);
+ 
+ #ifdef __cplusplus
+ }


### PR DESCRIPTION
The signature of ioctl uses a signed int as second argument. This, however, differs from the definition in Linux, glibc, and our own implementation in Unikraft, which use an unsigned long. Since using int has lead to all sorts of problems (e.g., overflow into sign bit), this commit adopts unsigned long also for the musl imported header.

This PR must be merged together with:
- https://github.com/unikraft/unikraft/pull/850