### PR TITLE
Fix C++ build issues w/ LLVM 14 (C++17 support)

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -21,6 +21,7 @@ $(LIBMUSL_BUILD)/include/$(1)/%.h:
 # includes for building libmusl
 LIBMUSL_$(call uc,$(1))_INCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/src/internal
 LIBMUSL_$(call uc,$(1))_INCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/src/$(1)
+LIBMUSL_$(call uc,$(1))_INCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/include
 LIBMUSL_SRCS-y += $(3)
 LIBMUSL_CINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)
 LIBMUSL_CXXINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -141,7 +141,7 @@ LIBMUSL_CFLAGS-y += -Wno-missing-braces
 LIBMUSL_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
 LIBMUSL_CFLAGS-y += -Wno-format-contains-nul
 LIBMUSL_CFLAGS-y += -Wno-type-limits
-LIBMUSL_CFLAGS-y += -DUK_LIBC_SYSCALL=0
+LIBMUSL_CFLAGS-y += -DUK_LIBC_SYSCALLS=0
 LIBMUSL_CFLAGS-y += -D_XOPEN_SOURCE=700
 LIBMUSL_CFLAGS-y += $(LIBMUSL_HDRS_FLAGS-y)
 


### PR DESCRIPTION
A set of fixes to enable building alongside LLVM 14 libcxx & friends:
- wrong macro set in build options
- missing declaration for prctl

This is part of a patch set consisting of:
 - [libcxx](https://github.com/unikraft/lib-libcxx/pull/28)
 - [libcxxabi](https://github.com/unikraft/lib-libcxxabi/pull/4)
 - [lib-compiler-rt](https://github.com/unikraft/lib-compiler-rt/pull/12)
 - [libunwind](https://github.com/unikraft/lib-libunwind/pull/7)
 - [musl](https://github.com/unikraft/lib-musl/pull/45)

Tested with GCC 11, 12 & 13, and clang 16.

edit: rebased & removed already upstreamed patches
edit2: rebased