### PR TITLE
Revert "Makefile.uk: Add flag to avoid gcc specifc symbol"

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -141,9 +141,6 @@ LIBMUSL_CFLAGS-y += -Wno-missing-braces
 LIBMUSL_CFLAGS-$(call gcc_version_ge,8,0) += -Wno-cast-function-type
 LIBMUSL_CFLAGS-y += -Wno-format-contains-nul
 LIBMUSL_CFLAGS-y += -Wno-type-limits
-ifeq ($(CONFIG_LIBMUSL_COMPLEX),y)
-LIBMUSL_CFLAGS-$(call have_clang) += -ffast-math
-endif
 LIBMUSL_CFLAGS-y += -DUK_LIBC_SYSCALL=0
 LIBMUSL_CFLAGS-y += -D_XOPEN_SOURCE=700
 LIBMUSL_CFLAGS-y += $(LIBMUSL_HDRS_FLAGS-y)


### PR DESCRIPTION
This reverts commit 4912487a42ec9ab1f7ab7bcca698c50a849eafa8.

`__muldc3` is implemented by `lib-compiler-rt` for clang, and emitting calls to it is normal. While -ffast-math prevents these calls, it also enables unsafe optimizations that might result in wrong results from math functions. Best to just pull in lib-compiler-rt when needed.

edit: also, with a newer clang (v16.0.1 on my end) musl fails to build with the -ffast-math flag:
```
.../apps/app-helloworld-cpp/build/libmusl/origin/musl-1.2.3//src/math/fmal.c:167:15: error: '#pragma STDC FENV_ACCESS ON' is illegal when precise is disabled
        #pragma STDC FENV_ACCESS ON
                     ^
```