### PR TITLE
`Config.uk`: Disable default LIBMUSL_COMPLEX

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -36,7 +36,7 @@ config LIBMUSL_AIO
 
 config LIBMUSL_COMPLEX
   bool "libcomplex"
-  default y
+  default n
 
 config LIBMUSL_CONF
   bool "libconf"


### PR DESCRIPTION
When using Clang to build Musl with complex numbers support, a linking error appears: `__muldc3` symbol is undefined. For Clang, the `__muldc3` symbol is implemented by `libcompiler-rt`.

As complex number support is not typically required by applications (that use Musl), this commit disable it by setting the `LIBMUSL_COMPLEX` option to `n`. If required, the application will enable `LIBMUSL_COMPLEX` (set it to `y`) and, in the case of Clang, add `libcompiler-rt`.