### PR TITLE
Allow deselection of ukmmap

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -4,7 +4,7 @@ menuconfig LIBMUSL
   default n
   select HAVE_LIBC
   select LIBKUALLOC
-  select LIBUKMMAP
+  imply  LIBUKMMAP
   select LIBSYSCALL_SHIM
   select LIBVFSCORE
   select LIBPOSIX_PROCESS


### PR DESCRIPTION
With posix-mmap we have an alternative implementation of the memory management functions such as mmap, mprotect, etc. To be able to select posix-mmap, we must deselect ukmmap. Thus, this commit removes the hard dependency.