### PR TITLE
glue: Init libc.auxv to point to a zero value

### DIFF
--- a/__uk_init_tls.c
+++ b/__uk_init_tls.c
@@ -159,9 +159,12 @@ static void __uk_init_tls(void *tls_area)
 		UK_CRASH("Failed to initialize the main thread\n");
 }
 
+/* We initialize the auxiliary vector to point to a zero value */
+static size_t __libc_auxv[1] = { 0 };
+
 static void __uk_init_libc(void)
 {
-	libc.auxv = 0;
+	libc.auxv = __libc_auxv;
 	__hwcap = 0;
 	__sysinfo = 0;
 	libc.page_size = __PAGE_SIZE;


### PR DESCRIPTION
The `libc.auxv` is not supposed to be 0, since it will be dereferenced by any call to `getauxval`.
It should point to a 0 value instead.