### PR TITLE
Makefile.uk: Condition behavior on Kconfig

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -27,8 +27,8 @@ LIBMUSL_CINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)
 LIBMUSL_CXXINCLUDES-y += $$(LIBMUSL_$(call uc,$(1))_INCLUDES-y)
 
 # includes for using libmusl
-CINCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/include
-CXXINCLUDES-y += -I$(LIBMUSL_BUILD)/include/$(1)/include
+CINCLUDES-$(CONFIG_LIBMUSL) += -I$(LIBMUSL_BUILD)/include/$(1)/include
+CXXINCLUDES-$(CONFIG_LIBMUSL) += -I$(LIBMUSL_BUILD)/include/$(1)/include
 
 # Append the sub library directory to the include path
 $(LIBMUSL_BUILD)/.prepared: $(subst $(LIBMUSL),$(LIBMUSL_BUILD)/include/$(1),$(2))

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -37,7 +37,9 @@
 # Please refer to ./arch/Makefile.rules for more details.
 # For this version of Musl the size of "struct pthread" is 200.
 ################################################################################
+ifeq ($(CONFIG_LIBMUSL),y)
 $(eval $(call ukarch_tls_tcb_reserve,200))
+endif
 
 ################################################################################
 # On aarch64, newer versions of musl no longer expect a 16-byte reserved block

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -45,8 +45,10 @@ endif
 # On aarch64, newer versions of musl no longer expect a 16-byte reserved block
 # at the end of the TCB. See: https://www.openwall.com/lists/musl/2018/06/01/14
 ################################################################################
+ifeq ($(CONFIG_LIBMUSL),y)
 ifeq (arm64,$(CONFIG_UK_ARCH))
 $(eval $(call aarch64_no_reserved_tcb_overlap))
+endif
 endif
 
 ################################################################################

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -98,8 +98,8 @@ LIBMUSL_COMPFLAGS-y += -I$(LIBMUSL)/arch/$(MUSL_ARCH)
 LIBMUSL_COMPFLAGS-y += -I$(LIBMUSL)/src/include
 LIBMUSL_COMPFLAGS-y += -I$(LIBMUSL)/src/internal
 
-CINCLUDES-y    += $(LIBMUSL_GLOBAL_INCLUDES-y)
-CXXINCLUDES-y  += $(LIBMUSL_GLOBAL_INCLUDES-y)
+CINCLUDES-$(CONFIG_LIBMUSL)    += $(LIBMUSL_GLOBAL_INCLUDES-y)
+CXXINCLUDES-$(CONFIG_LIBMUSL)  += $(LIBMUSL_GLOBAL_INCLUDES-y)
 
 ################################################################################
 # Musl-specific Targets
@@ -159,8 +159,8 @@ LIBMUSL_ASFLAGS-y += -Wno-unused-command-line-argument
 LIBMUSL_CFLAGS-y += -ffreestanding
 
 # We globally switch off warnings that are caused by musl's public headers
-CFLAGS += $(LIBMUSL_HDRS_FLAGS-y)
-CXXFLAGS += $(LIBMUSL_HDRS_FLAGS-y)
+CFLAGS-$(CONFIG_LIBMUSL) += $(LIBMUSL_HDRS_FLAGS-y)
+CXXFLAGS-$(CONFIG_LIBMUSL) += $(LIBMUSL_HDRS_FLAGS-y)
 
 ################################################################################
 # OS dependencies code - Glue between Unicore and musl


### PR DESCRIPTION
Previously musl's Makefile would unconditionally:
- reserve a TCB size
- (on AARCH64) unreserve said TCB size
- add musl headers to build include path

, regardless of whether musl was selected for build in Kconfig.
This change set makes these things happen only when musl is selected.

edit: updated w/ new commits