### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "musl"
+description := "A portable standard C library targetting the Linux syscall API."
+homepage    := "https://www.musl-libc.org/"
+license     := "MIT"
+version     := 1.2.3 sha256:7d5b0b6062521e4627e099e4c9dc8248d32a30285e959b7eecaa780cf8cfd4a4 https://www.musl-libc.org/releases/musl-1.2.3.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

