### PR TITLE
Makefile.uk.musl.exit: Patch for building on MacOS

### DIFF
--- a/Makefile.uk.musl.exit
+++ b/Makefile.uk.musl.exit
@@ -10,6 +10,8 @@ LIBMUSL_EXIT_HDRS-y += $(LIBMUSL)/include/stdio.h
 LIBMUSL_EXIT_HDRS-y += $(LIBMUSL)/include/stdlib.h
 LIBMUSL_EXIT_HDRS-y += $(LIBMUSL)/include/syscall.h
 
+$(LIBMUSL)/src/exit/__Exit.c: $(LIBMUSL_BUILD)/.origin
+		@ln $(LIBMUSL)/src/exit/_Exit.c $@
 
 LIBMUSL_EXIT_SRCS-y += $(LIBMUSL_BASE)/abort.c
 LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/abort_lock.c
@@ -17,7 +19,7 @@ LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/assert.c
 LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/atexit.c
 LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/at_quick_exit.c
 LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/exit.c
-LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/_Exit.c
+LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/__Exit.c
 LIBMUSL_EXIT_SRCS-y += $(LIBMUSL)/src/exit/quick_exit.c
 
 $(eval $(call _libmusl_import_lib,exit,$(LIBMUSL_EXIT_HDRS-y),$(LIBMUSL_EXIT_SRCS-y)))


### PR DESCRIPTION
Hack to rename `_Exit` file to `__Exit` because of case sensitivity issuses on Darwin.