### PR TITLE
Makefile.uk: Include missing gettid implementation

### DIFF
--- a/Makefile.uk.musl.linux
+++ b/Makefile.uk.musl.linux
@@ -54,6 +54,7 @@ LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/fanotify.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/flock.c
 LIBMUSL_LINUX_SRCS-$(CONFIG_LIBUKSWRAND) += $(LIBMUSL)/src/linux/getrandom.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/getdents.c
+LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/gettid.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/inotify.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/ioperm.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/iopl.c


### PR DESCRIPTION
The linux library was missing the implementation of gettid(). This change corrects this omission.