### PR TITLE
Config.uk: Add `uksignal` dependency for `LIBMUSL_SIGNAL`

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -170,6 +170,7 @@ config LIBMUSL_SETJMP
 config LIBMUSL_SIGNAL
   bool "libsignal"
   default y
+  select LIBUKSIGNAL
 
 config LIBMUSL_STAT
   bool "libstat"


### PR DESCRIPTION
`uksignal`  should be selected automatically when `LIBMUSL_SIGNAL` is enabled, since it relies on underlying syscalls to be implemented by the kernel.

Without it, we may run into issues such as this [one](https://github.com/unikraft/lib-musl/issues/57), where `SIG_ERROR` is returned when calling `signal()` and `uksignal` is disabled.