### PR TITLE
Makefile.uk.musl.misc: Add `memory.h` header

### DIFF
--- a/Makefile.uk.musl.misc
+++ b/Makefile.uk.musl.misc
@@ -13,6 +13,7 @@ LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/libgen.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/limits.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/src/internal/locale_impl.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/src/internal/lock.h
+LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/memory.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/mntent.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/pthread.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/src/internal/pthread_impl.h


### PR DESCRIPTION
Sometimes, apps and libraries choose to use `memory.h` instead of `strings.h`. While `musl` provides this header, currently it is not included in any existent library.
We include it in the `misc` one in order to avoid further patching the apps and libs to use `string.h`.

One example of such library is `lib-openssl`, which, for the crypto functionality, asks for `memory.h`:

```Makefile
/home/maria/arm/apps/app-helloworld/build/libssl/origin/openssl-1.1.1c/crypto/pkcs7/bio_pk7.c:15:11: fatal error: memory.h: No such file or directory
   15 | # include <memory.h>
      |           ^~~~~~~~~~
compilation terminated.
```