### PR TITLE
Makefile.uk.musl.misc: Add missing ar.h

### DIFF
--- a/Makefile.uk.musl.misc
+++ b/Makefile.uk.musl.misc
@@ -42,6 +42,7 @@ LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/unistd.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/utmp.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/wchar.h
 LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/wordexp.h
+LIBMUSL_MISC_HDRS-y += $(LIBMUSL)/include/ar.h
 
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/a64l.c
 LIBMUSL_MISC_SRCS-y += $(LIBMUSL)/src/misc/basename.c


### PR DESCRIPTION
This commit adds the ar.h header which is necessary for libelf to the musl header file list.