### PR TITLE
Option to handle DNS requesets by lwIP

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -135,6 +135,13 @@ config LIBMUSL_NETWORK
   bool "libnetwork"
   default y
 
+config LIBMUSL_NETWORK_LWIP_DNS
+  bool "Forward DNS requests to lwIP"
+  depends on LIBMUSL_NETWORK
+  depends on LIBLWIP
+  select LWIP_DNS
+  select LWIP_SOCKET
+
 config LIBMUSL_PASSWD
   bool "libpasswd"
   default y

--- a/Makefile.uk.musl.network
+++ b/Makefile.uk.musl.network
@@ -67,8 +67,10 @@ LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gai_strerror.c
 ifeq ($(filter y,$(CONFIG_LIBMUSL_NETWORK_LWIP_DNS)),)
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getaddrinfo.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/freeaddrinfo.c
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getnameinfo.c
 else
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/getaddrinfo.c
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/getnameinfo.c
 endif
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr_r.c
@@ -77,7 +79,6 @@ LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname2.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname2_r.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname_r.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getifaddrs.c
-LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getnameinfo.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getservbyname.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getservbyname_r.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getservbyport.c

--- a/Makefile.uk.musl.network
+++ b/Makefile.uk.musl.network
@@ -68,16 +68,17 @@ ifeq ($(filter y,$(CONFIG_LIBMUSL_NETWORK_LWIP_DNS)),)
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getaddrinfo.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/freeaddrinfo.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getnameinfo.c
-else
-LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/getaddrinfo.c
-LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/getnameinfo.c
-endif
-LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr.c
-LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr_r.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname2.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname2_r.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname_r.c
+else
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/getaddrinfo.c
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/getnameinfo.c
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/gethostbyname.c
+endif
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr.c
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr_r.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getifaddrs.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getservbyname.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getservbyname_r.c

--- a/Makefile.uk.musl.network
+++ b/Makefile.uk.musl.network
@@ -63,9 +63,13 @@ LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/dn_skipname.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/dns_parse.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/ent.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/ether.c
-LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/freeaddrinfo.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gai_strerror.c
+ifeq ($(filter y,$(CONFIG_LIBMUSL_NETWORK_LWIP_DNS)),)
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/getaddrinfo.c
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/freeaddrinfo.c
+else
+LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL_BASE)/lwip/getaddrinfo.c
+endif
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyaddr_r.c
 LIBMUSL_NETWORK_SRCS-y += $(LIBMUSL)/src/network/gethostbyname.c

--- a/lwip/getaddrinfo.c
+++ b/lwip/getaddrinfo.c
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#include <netdb.h>
+#include <lwip/netdb.h>
+
+int getaddrinfo(const char *restrict host, const char *restrict serv,
+		const struct addrinfo *restrict hint,
+		struct addrinfo **restrict res)
+{
+	return lwip_getaddrinfo(host, serv, hint, res);
+}
+
+void freeaddrinfo(struct addrinfo *ai)
+{
+	lwip_freeaddrinfo(ai);
+}

--- a/lwip/gethostbyname.c
+++ b/lwip/gethostbyname.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright (c) 2023, Unikraft GmbH and The Unikraft Authors.
+ * Licensed under the BSD-3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ */
+
+#define _GNU_SOURCE /* Enables h_errno and constants */
+#include <netdb.h>
+#include <lwip/netdb.h>
+#include <uk/print.h>
+#include <uk/essentials.h>
+
+struct hostent *gethostbyname(const char *name) {
+	return lwip_gethostbyname(name);
+}
+
+struct hostent *gethostbyname2(const char *name __unused, int af __unused) {
+	/* Not supported by lwip, but the function is deprecated anyways
+	 * (like the other gethostbyname() variants)
+	 */
+	UK_WARN_STUBBED();
+
+	h_errno = NO_RECOVERY;
+	return NULL;
+}
+
+int gethostbyname_r(const char *name, struct hostent *ret, char *buf,
+		    size_t buflen, struct hostent **result, int *h_errnop)
+{
+	return lwip_gethostbyname_r(name, ret, buf, buflen, result, h_errnop);
+}
+
+int gethostbyname2_r(const char *name __unused, int af __unused,
+		     struct hostent *ret __unused, char *buf __unused,
+		     size_t buflen __unused, struct hostent **result __unused,
+		     int *h_errnop __unused)
+{
+	/* Not supported by lwip */
+	UK_WARN_STUBBED();
+
+	if (h_errnop)
+		*h_errnop = NO_RECOVERY;
+	return -1;
+}

--- a/lwip/getnameinfo.c
+++ b/lwip/getnameinfo.c
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: BSD-3-Clause AND MIT */
+/*
+ * Copyright (C) 2014, Cloudius Systems, Ltd.
+ * Copyright (c) 2019, University Politehnica of Bucharest.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the author nor the names of any co-contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+/* For the parts taken from musl (marked as such below), the MIT licence
+ * applies instead:
+ * ----------------------------------------------------------------------
+ * Copyright (c) 2005-2014 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * ----------------------------------------------------------------------
+ */
+#include <lwip/opt.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <string.h>
+
+int getnameinfo(const struct sockaddr *restrict sa, socklen_t sl,
+	char *restrict node, socklen_t nodelen,
+	char *restrict serv, socklen_t servlen,
+	int flags)
+{
+	char buf[256];
+	/*unsigned char reply[512]; TODO used in DNS reply */
+	int af = sa->sa_family;
+	char line[512];
+	FILE *f;
+	unsigned char *a;
+
+	switch (af) {
+	case AF_INET:
+		a = (void *) &((struct sockaddr_in *) sa)->sin_addr;
+		if (sl != sizeof(struct sockaddr_in))
+			return EAI_FAMILY;
+		break;
+#if CONFIG_LWIP_IPV6
+	case AF_INET6:
+		a = (void *) &((struct sockaddr_in6 *) sa)->sin6_addr;
+		if (sl != sizeof(struct sockaddr_in6))
+			return EAI_FAMILY;
+		break;
+#endif
+	default:
+		return EAI_FAMILY;
+	}
+
+	/* Try to find ip within /etc/hosts */
+	if ((node && nodelen) && (af == AF_INET)) {
+		const char *ipstr;
+		size_t l;
+
+		ipstr = inet_ntoa(((struct sockaddr_in *)sa)->sin_addr);
+		l = strlen(ipstr);
+		f = fopen("/etc/hosts", "r");
+		if (f)
+			while (fgets(line, sizeof(line), f)) {
+				char *domain;
+
+				if (strncmp(line, ipstr, l) != 0)
+					continue;
+
+				domain = strtok(line, " ");
+				if (!domain)
+					continue;
+				domain = strtok(NULL, " ");
+				if (!domain)
+					continue;
+
+				if (strlen(domain) >= nodelen)
+					return EAI_OVERFLOW;
+				strcpy(node, domain);
+				fclose(f);
+				return 0;
+			}
+		if (f)
+			fclose(f);
+	}
+
+	if (node && nodelen) {
+		if ((flags & NI_NUMERICHOST)
+#if 0
+			/* TODO we currently don't support name requests */
+			|| __dns_query(reply, a, af, 1) <= 0
+			|| __dns_get_rr(buf, 0, 256, 1, reply, RR_PTR, 1) <= 0) {
+#else
+			|| 1) {
+#endif
+			if (flags & NI_NAMEREQD)
+				return EAI_NONAME;
+			inet_ntop(af, a, buf, sizeof(buf));
+		}
+		if (strlen(buf) >= nodelen)
+			return EAI_OVERFLOW;
+		strcpy(node, buf);
+	}
+
+	if (serv && servlen) {
+		if (snprintf(buf, sizeof(buf), "%d",
+			ntohs(((struct sockaddr_in *) sa)->sin_port)) >= (int) servlen)
+			return EAI_OVERFLOW;
+		strcpy(serv, buf);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
This PR introduces an option to use lwIP's DNS resolution for `getaddrinfo()`, `getnameinfo()`, `gethostbyname()`, and family. It can be enabled if lwIP is available. It will enable lwIP's DNS and socket interfaces.
The advantages of this implementation is that
1) there needs to place an `/etc/resolv.conf` in the VFS,
2) Works with DNS servers that lwIP got assigned with a DHCP reply.

This PR depends on PR [#48](https://github.com/unikraft/lib-lwip/pull/48) for lib/lwip.