### PR TITLE
libsched: Add sys/membarrier.h to provided headers

### DIFF
--- a/Makefile.uk.musl.sched
+++ b/Makefile.uk.musl.sched
@@ -1,5 +1,6 @@
 LIBMUSL_SCHED_HDRS-y += $(LIBMUSL)/src/internal/atomic.h
 LIBMUSL_SCHED_HDRS-y += $(LIBMUSL)/include/errno.h
+LIBMUSL_SCHED_HDRS-y += $(LIBMUSL)/include/sys/membarrier.h
 LIBMUSL_SCHED_HDRS-y += $(LIBMUSL)/src/internal/pthread_impl.h
 LIBMUSL_SCHED_HDRS-y += $(LIBMUSL)/include/sched.h
 LIBMUSL_SCHED_HDRS-y += $(LIBMUSL)/include/string.h


### PR DESCRIPTION
Add sys/membarrier.h to the headers provided by libsched.

This header is used by uksched begginning with https://github.com/unikraft/unikraft/pull/1321, which libsched pulls in.