### PR TITLE
Makefile.uk.*: Use Musl mallocng memory allocator

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -165,7 +165,7 @@ CXXFLAGS-$(CONFIG_LIBMUSL) += $(LIBMUSL_HDRS_FLAGS-y)
 ################################################################################
 # OS dependencies code - Glue between Unicore and musl
 ################################################################################
-LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/mem.c
+#LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/mem.c
 LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/__uk_init_tls.c
 LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/__uk_unmapself.c
 LIBMUSLGLUE_SRCS-y += $(LIBMUSL_BASE)/__set_thread_area.c

--- a/Makefile.uk.musl.malloc
+++ b/Makefile.uk.musl.malloc
@@ -9,6 +9,25 @@ LIBMUSL_MALLOC_HDRS-y += $(LIBMUSL)/include/stdlib.h
 LIBMUSL_MALLOC_HDRS-y += $(LIBMUSL)/include/string.h
 LIBMUSL_MALLOC_HDRS-y += $(LIBMUSL)/src/internal/syscall.h
 LIBMUSL_MALLOC_HDRS-y += $(LIBMUSL)/include/sys/mman.h
+LIBMUSL_MALLOC_HDRS-y += $(LIBMUSL)/arch/aarch64/mte.h
 
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/aligned_alloc.c|mallocng
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/donate.c|mallocng
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/free.c|mallocng
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/glue.h|mallocng
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/malloc.c|mallocng
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/malloc_usable_size.c|mallocng
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/meta.h|mallocng
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/mallocng/realloc.c|mallocng
+
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/free.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/libc_calloc.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/lite_malloc.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/memalign.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/posix_memalign.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/reallocarray.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/realloc.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/calloc.c
+LIBMUSL_MALLOC_SRCS-y += $(LIBMUSL)/src/malloc/replaced.c
 
 $(eval $(call _libmusl_import_lib,malloc,$(LIBMUSL_MALLOC_HDRS-y),$(LIBMUSL_MALLOC_SRCS-y)))


### PR DESCRIPTION
Use the Musl memory allocator instead of the wrappers over `uk_alloc`.