### PR TITLE
uk_init_tls: Initialize the TSD to the value expected by musl

### DIFF
--- a/__uk_init_tls.c
+++ b/__uk_init_tls.c
@@ -116,12 +116,10 @@ static int __uk_init_tp(void *p)
 	 */
 	memset(td, 0, sizeof(*td));
 
-	td->tsd = (void *)uk_memalign(uk_alloc_get_default(), __PAGE_SIZE,
-							__uk_tsd_size);
-	if (!td->tsd)
-		UK_CRASH("Failed to initialize init thread tsd\n");
-
-	memset(td->tsd, 0, __uk_tsd_size);
+	/* The first call to pthread_create will set unconditionally the tsd
+	 * field to point to __pthread_tsd_main so we initialize it already to
+	 * that value */
+	td->tsd = __pthread_tsd_main;
 
 	/*
 	 * The initial thread in the new image shall be joinable, as if


### PR DESCRIPTION
Even if the TSD has been initialized already, the first call to `pthread_create` will (re)set it to point to the statically-allocated `__pthread_tsd_main` (see (1)). So, before this patch, the memory allocated for the TSD leaked and, worse, the following sequence:

```
pthread_key_create(&key, NULL);
pthread_setspecific(key, value);
assert(pthread_getspecific(key) == value);
pthread_create(&th, NULL, &thrd, NULL);
assert(pthread_getspecific(key) == value);
```

ended up with the final assertion failing.

I’ve tested this example without and with the modification in CI:
- the [code](https://github.com/shym/unikraft-simple/tree/tsd)
- until they expire, the log on [staging](https://github.com/shym/unikraft-simple/actions/runs/11350999826/job/31570652113#step:7:16) and the one [with the patch](https://github.com/shym/unikraft-simple/actions/runs/11351080432/job/31570907359#step:7:14).

(1) src/thread/pthread_create.c line 255 in musl v1.2.3

This was discovered investigating a segfault in the OCaml runtime, where some information is stored in the TSD in all cases, even for the initial thread. Accessing that information after a new thread has been created triggered the segfault.