### PR TITLE
Config.uk: Add posix-tty as dependency to stdio

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -189,6 +189,8 @@ config LIBMUSL_STDIO
   default y
   select LIBMUSL_FENV
   select LIBMUSL_UNISTD
+  select LIBPOSIX_TTY
+  select LIBPOSIX_TTY_STDIO
 
 config LIBMUSL_STDLIB
   bool "libstdlib"


### PR DESCRIPTION
This change adds an explicit dependency on posix-tty and its STDIO option for when the libstdio sub-lib of musl is enabled. This makes musl's assumption that fds 0, 1, 2 be opened to something meaningful an explicit configuration requirement on the kernel.

Without this fix, musl's stdio will no longer work as expected after https://github.com/unikraft/unikraft/pull/1437.