### PR TITLE
arch/arm64: Save/restore link register on `clone` asm stub

### DIFF
--- a/arch/arm64/__clone.S
+++ b/arch/arm64/__clone.S
@@ -11,10 +11,16 @@
  */
 .global __clone
 __clone:
+	/* We must also save the link/frame register because no one else will
+	 * do it for us since we are invoking a function call not a system call
+	 */
+	stp	x29, x30, [sp, #-32]!
+	mov	x29, sp
+
 	/* Save fn and arg in callee-saved registers, but first make sure
 	 * we can also restore them before returning in the parent.
 	 */
-	stp	x20, x21, [sp, #-16]
+	stp	x20, x21, [sp, #16]
 	mov	x20, x0
 	mov	x21, x3
 
@@ -62,5 +68,7 @@ __clone:
 
 1:
 	/* Restore the registers saved in the beginning */
-	ldp	x20, x21, [sp, #-16]
+	ldp	x20, x21, [sp, #16]
+	ldp	x29, x30, [sp], #32
+
 	ret


### PR DESCRIPTION
Since we are invoking `clone` as a regular function call instead of a system call, there is nobody to remember the asm stub entry link register for us once we branch into the syscall. Therefore save and restore it.