### PR TITLE
.github/workflows: Remove merge-stable from integration

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -94,23 +94,3 @@ jobs:
           exit 1;
         env:
           GITHUB_TOKEN: ${{ secrets.GH_CATALOG_PAT }}
-
-
-  merge-stable:
-    needs: [catalog-tests]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/staging' && github.repository_owner == 'unikraft' }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: staging
-
-      - name: Merge stable
-        run: |
-          set -e;
-
-          git pull origin stable;
-          git checkout --track origin/stable;
-          git rebase staging;
-          git push origin stable;


### PR DESCRIPTION
Remove the merge-stable rule from integration.yaml to prevent automatically merging patches from staging into stable. The rationale is that right now that tests are still not comprehensive, and it's still unclear how to correctly handle large feature sets that consist of multiple PRs.