### PR TITLE
Don't exclude `sendfile` if `lwip` is enabled

### DIFF
--- a/Makefile.uk.musl.linux
+++ b/Makefile.uk.musl.linux
@@ -73,9 +73,7 @@ LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/readahead.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/reboot.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/remap_file_pages.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/sbrk.c
-ifneq ($(CONFIG_LIBLWIP),y)
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/sendfile.c
-endif
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/setfsgid.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/setfsuid.c
 LIBMUSL_LINUX_SRCS-y += $(LIBMUSL)/src/linux/setgroups.c


### PR DESCRIPTION
Our lwip port used to have a stubbed implementation of `sendfile`, but now we have our own proper implementation in the core repository and the stub from lwip has been removed.

Therefore, we no longer need to exclude musl's `sendfile` if lwip is enabled. Musl will now call into the core's `sendfile` instead.