### PR TITLE
Bump upstream Musl version to 1.2.5

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -64,7 +64,7 @@ $(eval $(call addlib_s,libmuslglue,$(CONFIG_LIBMUSL)))
 ################################################################################
 # Sources
 ################################################################################
-LIBMUSL_VERSION=1.2.3
+LIBMUSL_VERSION=1.2.5
 LIBMUSL_URL=https://www.musl-libc.org/releases/musl-$(LIBMUSL_VERSION).tar.gz
 LIBMUSL_PATCHDIR=$(LIBMUSL_BASE)/patches
 $(eval $(call fetch,libmusl,$(LIBMUSL_URL)))


### PR DESCRIPTION
Bumped LIBMUSL_VERSION to 1.2.5. Verified locally via `make prepare` that the existing patch stack (0001-0020) applies cleanly to the new source tree without requiring any rebasing.